### PR TITLE
Remove random.seed call in essay_set

### DIFF
--- a/ease/essay_set.py
+++ b/ease/essay_set.py
@@ -130,7 +130,6 @@ class EssaySet(object):
         dictionary is a fixed dictionary (list) of words to replace.
         max_syns defines the maximum number of additional essays to generate.  Do not set too high.
         """
-        random.seed(1)
         e_toks = nltk.word_tokenize(e_text)
         all_syns = []
         for word in e_toks:


### PR DESCRIPTION
The test suite still passes with the random seed reset line removed.

@VikParuchuri Is there a reason to keep this line in?  I'm concerned that it will cause issues when run in the same process as other Celery tasks.
