### PR TITLE
Change error logging for an error we're suppressing to debug logging

### DIFF
--- a/ease/model_creator.py
+++ b/ease/model_creator.py
@@ -101,9 +101,10 @@ def get_cv_error(clf,feats,scores):
         results['mae']=err
         results['kappa']=kappa
         results['success']=True
-    except ValueError:
-        #If this is hit, everything is fine.  It is hard to explain why the error occurs, but it isn't a big deal.
-        log.exception("Not enough classes (0,1,etc) in each cross validation fold.")
+    except ValueError as ex:
+        # If this is hit, everything is fine.  It is hard to explain why the error occurs, but it isn't a big deal.
+        msg = u"Not enough classes (0,1,etc) in each cross validation fold: {ex}".format(ex=ex)
+        log.debug(msg)
     except:
         log.exception("Error getting cv error estimates.")
 


### PR DESCRIPTION
@stephensanchez This really scary error message was showing up in the worker logs while I was testing.  However, it looks like the error occurs when running cross-validation, so even if this exception occurs, the classifiers will still be trained successfully.  EASE seems to be swallowing the exception, but logging it as an error, so I've downgraded the logging to a debug statement.
