### PR TITLE
Download only the NLTK data we actually use

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,9 @@ before_install:
   - sudo apt-get update
   - sudo xargs -a apt-packages.txt apt-get install --fix-missing
 install:
-  - travis_retry ./download-nltk-corpus.sh
   - pip install -r base-requirements.txt
   - pip install -r dev-requirements.txt
   - sudo apt-get install python-matplotlib python-numpy python-scipy python-sklearn
   - pip install nltk==2.0.3 scikit-learn==0.12.1
+  - travis_retry ./download-nltk-corpus.sh
 script:  nosetests

--- a/download-nltk-corpus.sh
+++ b/download-nltk-corpus.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 
-curl -o /tmp/nltk.tmp.tar.tz http://edx-static.s3.amazonaws.com/nltk/nltk-data-20131113.tar.gz
-cd /usr/share && sudo tar zxf /tmp/nltk.tmp.tar.tz
+PYTHON=`which python`
+sudo $PYTHON -m nltk.downloader stopwords maxent_treebank_pos_tagger wordnet -d /usr/local/share/nltk_data


### PR DESCRIPTION
Instead of downloading the 600 MB archive of NLTK data, use the NLTK downloader to retrieve only the taggers and corpora that we actually use.

@feanil 
