### PR TITLE
Upgrade scikit to 0.14.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,6 @@ install:
   - pip install -r base-requirements.txt
   - pip install -r dev-requirements.txt
   - sudo apt-get install python-matplotlib python-numpy python-scipy python-sklearn
-  - pip install nltk==2.0.3 scikit-learn==0.12.1
+  - pip install nltk==2.0.3 scikit-learn==0.14.1
   - travis_retry ./download-nltk-corpus.sh
 script:  nosetests

--- a/ease/model_creator.py
+++ b/ease/model_creator.py
@@ -116,14 +116,14 @@ def get_algorithms(algorithm):
     type - one of util_functions.AlgorithmTypes
     """
     if algorithm == util_functions.AlgorithmTypes.classification:
-        clf = sklearn.ensemble.GradientBoostingClassifier(n_estimators=100, learn_rate=.05,
+        clf = sklearn.ensemble.GradientBoostingClassifier(n_estimators=100, learning_rate=.05,
             max_depth=4, random_state=1,min_samples_leaf=3)
-        clf2=sklearn.ensemble.GradientBoostingClassifier(n_estimators=100, learn_rate=.05,
+        clf2=sklearn.ensemble.GradientBoostingClassifier(n_estimators=100, learning_rate=.05,
             max_depth=4, random_state=1,min_samples_leaf=3)
     else:
-        clf = sklearn.ensemble.GradientBoostingRegressor(n_estimators=100, learn_rate=.05,
+        clf = sklearn.ensemble.GradientBoostingRegressor(n_estimators=100, learning_rate=.05,
             max_depth=4, random_state=1,min_samples_leaf=3)
-        clf2=sklearn.ensemble.GradientBoostingRegressor(n_estimators=100, learn_rate=.05,
+        clf2=sklearn.ensemble.GradientBoostingRegressor(n_estimators=100, learning_rate=.05,
             max_depth=4, random_state=1,min_samples_leaf=3)
     return clf, clf2
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 -r base-requirements.txt
 scipy==0.11.0
-scikit-learn==0.12.1
+scikit-learn==0.14.1
 nltk==2.0.3


### PR DESCRIPTION
If we end up using scikit directly on ORA2, we'll need the version in EASE to be compatible.  This PR updates scikit-learn to version `0.14.1` in preparation for that.

Not sure if this will end up being necessary or not, but keeping it open just in case.
