### PR TITLE
Use a set instead of a list for good ngram lookup

### DIFF
--- a/ease/feature_extractor.py
+++ b/ease/feature_extractor.py
@@ -74,8 +74,8 @@ class FeatureExtractor(object):
 
     def get_good_pos_ngrams(self):
         """
-        Gets a list of gramatically correct part of speech sequences from an input file called essaycorpus.txt
-        Returns the list and caches the file
+        Gets a set of gramatically correct part of speech sequences from an input file called essaycorpus.txt
+        Returns the set and caches the file
         """
         if(os.path.isfile(NGRAM_PATH)):
             good_pos_ngrams = pickle.load(open(NGRAM_PATH, 'rb'))
@@ -92,7 +92,7 @@ class FeatureExtractor(object):
              'NNP .', 'NNP . TO', 'NNP . TO NNP', '. TO', '. TO NNP', '. TO NNP NNP',
              'TO NNP', 'TO NNP NNP']
 
-        return good_pos_ngrams
+        return set(good_pos_ngrams)
 
     def _get_grammar_errors(self,pos,text,tokens):
         """


### PR DESCRIPTION
When finding grammar errors, EASE checks whether each ngram in the submission is in a list called `good_pos_ngrams`.  This is an O(n) operation that occurs for each ngram in the submission.

By changing the `list` to a `set`, the `in` operation is O(1) in the average case, which results in a pretty dramatic speedup.  When I profiled the algorithm on my laptop, I saw an improvement of about 71%.

@stephensanchez Please review.  I'd like to get this in and re-run the perf test on dev.
