### PR TITLE
Update scipy to 0.14.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 -r base-requirements.txt
-scipy==0.11.0
+scipy==0.14.0
 scikit-learn==0.12.1
 nltk==2.0.4


### PR DESCRIPTION
For compatibility with https://github.com/edx/edx-platform/pull/4582. Release notes: [0.12.0](http://docs.scipy.org/doc/scipy/reference/release.0.12.0.html), [0.13.0](http://docs.scipy.org/doc/scipy/reference/release.0.13.0.html), [0.14.0](http://docs.scipy.org/doc/scipy/reference/release.0.14.0.html)
