### PR TITLE
Update pytz to 2015.2

### DIFF
--- a/base-requirements.txt
+++ b/base-requirements.txt
@@ -6,5 +6,5 @@
 
 lxml==3.0.1
 path.py==3.0
-pytz==2012h
+pytz==2015.2
 fisher==0.1.4


### PR DESCRIPTION
pytz changed their versioning scheme from using letters to using
numbers. The old scheme is screwing up new versions of pip.