### PR TITLE
Make path.py a dynamic requirement (don't specify version)

### DIFF
--- a/base-requirements.txt
+++ b/base-requirements.txt
@@ -5,6 +5,6 @@
 # every time.
 
 lxml==3.0.1
-path.py==3.0
+path.py
 pytz==2015.2
 fisher==0.1.4


### PR DESCRIPTION
ease is a library, and it should be more flexible with the versions of its requirements. Useful for https://github.com/edx/edx-platform/pull/7429