### PR TITLE
Remove "obsolete", as ease is a requirement of ora2.

### DIFF
--- a/openedx.yaml
+++ b/openedx.yaml
@@ -3,4 +3,4 @@
 
 oeps: {}
 owner: edx/teaching-and-learning
-obsolete: True
+


### PR DESCRIPTION
I don't think this should have been marked obsolete. edx-ora2 declares ease as a dependency (though I don't think it is used by any code we are actually running in production).

@edx/teaching-and-learning: please review

FYI @staubina 