### PR TITLE
Remove django-sphinx-autodoc package

### DIFF
--- a/requirements/doc.in
+++ b/requirements/doc.in
@@ -2,5 +2,4 @@
 
 -r base.txt                         # Core dependencies
 
-django-sphinx-autodoc
 sphinx

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -8,7 +8,6 @@ alabaster==0.7.12         # via sphinx
 babel==2.8.0              # via sphinx
 certifi==2020.6.20        # via requests
 chardet==3.0.4            # via requests
-django-sphinx-autodoc==0.2  # via -r requirements/doc.in
 docutils==0.16            # via sphinx
 fisher==0.1.9             # via -r requirements/base.txt
 idna==2.10                # via requests


### PR DESCRIPTION
This PR was created to remove django-sphinx-autodoc in order to close https://github.com/edx/upgrades/issues/66 Django 3.2 issue